### PR TITLE
Add clood bonsai command for ASCII tree generation

### DIFF
--- a/clood-cli/cmd/clood/main.go
+++ b/clood-cli/cmd/clood/main.go
@@ -82,6 +82,7 @@ func main() {
 	rootCmd.AddCommand(commands.AgentsCmd())
 	rootCmd.AddCommand(commands.HealthCmd())
 	rootCmd.AddCommand(commands.TuneCmd())
+	rootCmd.AddCommand(commands.BonsaiCmd())
 
 	// Code analysis commands
 	rootCmd.AddCommand(commands.GrepCmd())

--- a/clood-cli/internal/commands/bonsai.go
+++ b/clood-cli/internal/commands/bonsai.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/dirtybirdnj/clood/internal/tui"
+	"github.com/spf13/cobra"
+)
+
+// Size presets for cbonsai
+var sizePresets = map[string][2]int{
+	"tiny":    {10, 2},
+	"small":   {20, 3},
+	"medium":  {32, 5},
+	"large":   {60, 8},
+	"ancient": {100, 12},
+}
+
+// BonsaiCmd returns a command that generates ASCII bonsai trees
+func BonsaiCmd() *cobra.Command {
+	var size string
+	var message string
+
+	cmd := &cobra.Command{
+		Use:   "bonsai",
+		Short: "Generate ASCII bonsai tree using cbonsai",
+		Long: `Generate beautiful ASCII bonsai trees for the Server Garden.
+
+The bonsai represents careful cultivation of local resources.
+Each tree is unique, grown from the seeds of your configuration.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Default to medium if no size specified
+			if size == "" {
+				size = "medium"
+			}
+
+			preset, ok := sizePresets[size]
+			if !ok {
+				return fmt.Errorf("invalid size: %s (use tiny/small/medium/large/ancient)", size)
+			}
+
+			life := preset[0]
+			multiplier := preset[1]
+
+			// Build cbonsai arguments
+			cbArgs := []string{
+				"-p", // Static mode (no animation)
+				fmt.Sprintf("-L%d", life),
+				fmt.Sprintf("-M%d", multiplier),
+			}
+
+			if message != "" {
+				cbArgs = append(cbArgs, "-m", message)
+			}
+
+			// Run cbonsai
+			cbCmd := exec.Command("cbonsai", cbArgs...)
+			output, err := cbCmd.CombinedOutput()
+			if err != nil {
+				// Check if cbonsai is installed
+				if _, lookErr := exec.LookPath("cbonsai"); lookErr != nil {
+					fmt.Println(tui.ErrorStyle.Render("cbonsai not found"))
+					fmt.Println(tui.MutedStyle.Render("Install with: brew install cbonsai"))
+					return nil
+				}
+				return fmt.Errorf("cbonsai error: %v\n%s", err, output)
+			}
+
+			fmt.Print(string(output))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&size, "size", "s", "", "Size preset (tiny/small/medium/large/ancient)")
+	cmd.Flags().StringVarP(&message, "message", "m", "", "Custom message to display")
+
+	return cmd
+}


### PR DESCRIPTION
## Summary
Implements `clood bonsai` command that generates ASCII bonsai trees using cbonsai.

Closes #18

## Features
- Size presets: `--size tiny/small/medium/large/ancient`
- Custom message: `--message "text"`
- Graceful error if cbonsai not installed

## Size Presets
| Preset | Life | Multiplier |
|--------|------|------------|
| tiny | 10 | 2 |
| small | 20 | 3 |
| medium | 32 | 5 |
| large | 60 | 8 |
| ancient | 100 | 12 |

## Usage
```bash
clood bonsai                    # Medium tree
clood bonsai --size large       # Large tree
clood bonsai -m "Server Garden" # With message
```

## Test Plan
- [x] `clood bonsai --help` shows flags
- [x] Build passes
- [ ] Test with cbonsai installed (requires manual)

## Catfight Origin
Implementation based on catfight winner patterns from overnight session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)