### PR TITLE
Add Focus Guardian (Gamera-kun) to chat command

### DIFF
--- a/clood-cli/internal/focus/focus.go
+++ b/clood-cli/internal/focus/focus.go
@@ -1,0 +1,190 @@
+package focus
+
+import (
+	"strings"
+	"unicode"
+)
+
+// Guardian implements focus drift detection
+// Named after Gamera-kun, the slow tortoise who guards against "stupid faster"
+type Guardian struct {
+	Goal             string
+	Keywords         []string
+	DriftCount       int
+	Threshold        int
+	RecentMessages   []string
+	MaxRecentHistory int
+}
+
+// DriftResult contains the analysis of a message
+type DriftResult struct {
+	IsDrift    bool
+	Confidence float64
+	Keywords   []string // Which goal keywords were found
+	Message    string   // The Gamera-kun message
+}
+
+// NewGuardian creates a focus guardian with default settings
+func NewGuardian(goal string) *Guardian {
+	g := &Guardian{
+		Goal:             goal,
+		Keywords:         extractKeywords(goal),
+		DriftCount:       0,
+		Threshold:        3,  // Warn after 3 drifted messages
+		MaxRecentHistory: 5,  // Track last 5 messages for pattern
+		RecentMessages:   []string{},
+	}
+	return g
+}
+
+// CheckMessage analyzes if a message drifts from the goal
+func (g *Guardian) CheckMessage(message string) DriftResult {
+	if g.Goal == "" {
+		return DriftResult{IsDrift: false}
+	}
+
+	// Extract keywords from message
+	msgKeywords := extractKeywords(message)
+
+	// Find overlapping keywords
+	matches := []string{}
+	for _, goalKw := range g.Keywords {
+		for _, msgKw := range msgKeywords {
+			if strings.EqualFold(goalKw, msgKw) ||
+			   strings.Contains(strings.ToLower(msgKw), strings.ToLower(goalKw)) ||
+			   strings.Contains(strings.ToLower(goalKw), strings.ToLower(msgKw)) {
+				matches = append(matches, goalKw)
+				break
+			}
+		}
+	}
+
+	// Calculate drift
+	confidence := float64(len(matches)) / float64(len(g.Keywords))
+	isDrift := len(matches) == 0
+
+	// Track recent messages
+	g.RecentMessages = append(g.RecentMessages, message)
+	if len(g.RecentMessages) > g.MaxRecentHistory {
+		g.RecentMessages = g.RecentMessages[1:]
+	}
+
+	// Update drift counter
+	if isDrift {
+		g.DriftCount++
+	} else {
+		g.DriftCount = 0 // Reset on relevant message
+	}
+
+	result := DriftResult{
+		IsDrift:    isDrift,
+		Confidence: confidence,
+		Keywords:   matches,
+	}
+
+	// Only warn if threshold reached
+	if isDrift && g.DriftCount >= g.Threshold {
+		result.Message = g.buildWarningMessage(message)
+	}
+
+	return result
+}
+
+// buildWarningMessage creates the Gamera-kun warning
+func (g *Guardian) buildWarningMessage(message string) string {
+	// Extract what the user seems to be talking about
+	newTopic := summarizeTopic(message)
+
+	return newTopic
+}
+
+// summarizeTopic extracts a brief description of the message topic
+func summarizeTopic(message string) string {
+	keywords := extractKeywords(message)
+	if len(keywords) == 0 {
+		return "something else"
+	}
+	if len(keywords) > 3 {
+		keywords = keywords[:3]
+	}
+	return strings.Join(keywords, ", ")
+}
+
+// Reset clears drift tracking (e.g., when user confirms they want to continue)
+func (g *Guardian) Reset() {
+	g.DriftCount = 0
+	g.RecentMessages = []string{}
+}
+
+// UpdateGoal changes the focus goal
+func (g *Guardian) UpdateGoal(newGoal string) {
+	g.Goal = newGoal
+	g.Keywords = extractKeywords(newGoal)
+	g.Reset()
+}
+
+// extractKeywords pulls meaningful words from text
+func extractKeywords(text string) []string {
+	// Common words to ignore
+	stopWords := map[string]bool{
+		"the": true, "a": true, "an": true, "is": true, "are": true,
+		"was": true, "were": true, "be": true, "been": true, "being": true,
+		"have": true, "has": true, "had": true, "do": true, "does": true,
+		"did": true, "will": true, "would": true, "could": true, "should": true,
+		"may": true, "might": true, "must": true, "can": true,
+		"i": true, "you": true, "he": true, "she": true, "it": true,
+		"we": true, "they": true, "me": true, "him": true, "her": true,
+		"us": true, "them": true, "my": true, "your": true, "his": true,
+		"its": true, "our": true, "their": true,
+		"this": true, "that": true, "these": true, "those": true,
+		"what": true, "which": true, "who": true, "whom": true,
+		"and": true, "or": true, "but": true, "if": true, "then": true,
+		"so": true, "as": true, "of": true, "at": true, "by": true,
+		"for": true, "with": true, "about": true, "to": true, "from": true,
+		"in": true, "on": true, "up": true, "out": true, "into": true,
+		"also": true, "just": true, "too": true, "very": true, "really": true,
+		"want": true, "need": true, "like": true, "please": true, "help": true,
+		"let": true, "now": true, "how": true, "why": true, "when": true,
+		"add": true, "fix": true, "make": true, "get": true, "put": true,
+	}
+
+	// Split on non-alphanumeric
+	words := strings.FieldsFunc(text, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+	})
+
+	// Filter and collect keywords
+	keywords := []string{}
+	seen := map[string]bool{}
+
+	for _, word := range words {
+		lower := strings.ToLower(word)
+		if len(lower) < 3 {
+			continue
+		}
+		if stopWords[lower] {
+			continue
+		}
+		if seen[lower] {
+			continue
+		}
+		seen[lower] = true
+		keywords = append(keywords, lower)
+	}
+
+	return keywords
+}
+
+// GetStatus returns a summary of the guardian's state
+func (g *Guardian) GetStatus() string {
+	if g.Goal == "" {
+		return "No goal set"
+	}
+	if g.DriftCount == 0 {
+		return "On track"
+	}
+	if g.DriftCount < g.Threshold {
+		return "Wandering slightly"
+	}
+	return "Drifting from goal"
+}

--- a/clood-cli/internal/focus/focus_test.go
+++ b/clood-cli/internal/focus/focus_test.go
@@ -1,0 +1,157 @@
+package focus
+
+import (
+	"testing"
+)
+
+func TestExtractKeywords(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{
+			input:    "fix the authentication bug",
+			expected: []string{"authentication", "bug"},
+		},
+		{
+			input:    "add a dark mode toggle",
+			expected: []string{"dark", "mode", "toggle"},
+		},
+		{
+			input:    "the quick brown fox",
+			expected: []string{"quick", "brown", "fox"},
+		},
+		{
+			input:    "",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := extractKeywords(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("extractKeywords(%q) = %v, want %v", tt.input, result, tt.expected)
+				return
+			}
+			for i, kw := range result {
+				if kw != tt.expected[i] {
+					t.Errorf("extractKeywords(%q)[%d] = %q, want %q", tt.input, i, kw, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGuardianDriftDetection(t *testing.T) {
+	g := NewGuardian("fix authentication bug")
+
+	// Related message - should not drift
+	result := g.CheckMessage("I found the authentication error in login.go")
+	if result.IsDrift {
+		t.Error("Expected no drift for related message")
+	}
+
+	// Reset for clean test
+	g.Reset()
+
+	// Unrelated messages - should eventually trigger drift
+	unrelateds := []string{
+		"What about adding a dark mode?",
+		"Can we also add a settings page?",
+		"Let's implement the export feature",
+	}
+
+	for i, msg := range unrelateds {
+		result = g.CheckMessage(msg)
+		if !result.IsDrift {
+			t.Errorf("Message %d should be detected as drift: %q", i, msg)
+		}
+	}
+
+	// After 3 drifted messages, should have a warning
+	if result.Message == "" {
+		t.Error("Expected warning message after threshold reached")
+	}
+}
+
+func TestGuardianReset(t *testing.T) {
+	g := NewGuardian("fix auth bug")
+
+	// Drift a bit
+	g.CheckMessage("unrelated message one")
+	g.CheckMessage("unrelated message two")
+
+	if g.DriftCount != 2 {
+		t.Errorf("Expected drift count 2, got %d", g.DriftCount)
+	}
+
+	g.Reset()
+
+	if g.DriftCount != 0 {
+		t.Errorf("Expected drift count 0 after reset, got %d", g.DriftCount)
+	}
+}
+
+func TestGuardianUpdateGoal(t *testing.T) {
+	g := NewGuardian("fix auth bug")
+
+	// Check initial keywords
+	if len(g.Keywords) != 2 {
+		t.Errorf("Expected 2 keywords, got %d: %v", len(g.Keywords), g.Keywords)
+	}
+
+	g.UpdateGoal("implement dark mode feature")
+
+	// Should have new keywords
+	if len(g.Keywords) != 4 {
+		t.Errorf("Expected 4 keywords after update, got %d: %v", len(g.Keywords), g.Keywords)
+	}
+
+	// Drift count should reset
+	if g.DriftCount != 0 {
+		t.Errorf("Expected drift count 0 after goal update, got %d", g.DriftCount)
+	}
+}
+
+func TestNoGoalNoDrift(t *testing.T) {
+	g := NewGuardian("")
+
+	// With no goal, nothing should be detected as drift
+	result := g.CheckMessage("absolutely anything")
+	if result.IsDrift {
+		t.Error("Expected no drift when goal is empty")
+	}
+}
+
+func TestPartialKeywordMatch(t *testing.T) {
+	g := NewGuardian("fix authentication bug")
+
+	// "auth" should match "authentication" via substring
+	result := g.CheckMessage("the auth module needs work")
+	if result.IsDrift {
+		t.Error("Expected partial keyword match for 'auth' -> 'authentication'")
+	}
+}
+
+func TestGetStatus(t *testing.T) {
+	g := NewGuardian("fix something")
+
+	status := g.GetStatus()
+	if status != "On track" {
+		t.Errorf("Expected 'On track', got %q", status)
+	}
+
+	g.CheckMessage("unrelated")
+	status = g.GetStatus()
+	if status != "Wandering slightly" {
+		t.Errorf("Expected 'Wandering slightly', got %q", status)
+	}
+
+	g.CheckMessage("still unrelated")
+	g.CheckMessage("even more unrelated")
+	status = g.GetStatus()
+	if status != "Drifting from goal" {
+		t.Errorf("Expected 'Drifting from goal', got %q", status)
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #29 - the "stupid faster" prevention system.

- **Focus Guardian**: Keyword-based drift detection that warns when conversation wanders from the stated goal
- **Gamera-kun UX**: ASCII box warning with tortoise mascot
- **Goal management**: `--goal` flag and `/goal` slash command
- **User agency**: Can continue anyway, update goal, or stay focused

## Features

### CLI Usage
```bash
clood chat --goal "fix authentication bug"
```

### Slash Commands
```
/goal                    # Show current goal
/goal fix the login page # Update goal
```

### Warning Example
```
┌─────────────────────────────────────────────┐
│ 🐢 Gamera-kun notices:                      │
│                                             │
│ "dark, mode, toggle" seems unrelated to:    │
│ "fix authentication bug"                    │
│                                             │
└─────────────────────────────────────────────┘

Continue anyway? [y/N/update goal]
```

## Implementation

- `internal/focus/focus.go` - Guardian logic with keyword extraction and drift detection
- `internal/focus/focus_test.go` - Comprehensive test coverage (7 tests, all passing)
- `internal/commands/chat.go` - Integration with chat REPL

## Philosophy

> *"I've taken a controversial new pill that accelerates my brain."*
> *"So you're smart now?"*
> *"I'm stupid FASTER."*

Fast LLMs don't make you smarter—they make you stupid faster. Gamera-kun is the slow tortoise who guards against this.

## Test plan

- [x] All focus package tests pass
- [ ] Manual test: `clood chat --goal "test goal"` starts with goal set
- [ ] Manual test: `/goal` shows current goal
- [ ] Manual test: `/goal new goal` updates goal
- [ ] Manual test: Off-topic messages trigger warning after 3 attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)